### PR TITLE
Canonicalize and ensure uniqueness of indices

### DIFF
--- a/lib/puppet/parser/functions/openldap_unique_indices.rb
+++ b/lib/puppet/parser/functions/openldap_unique_indices.rb
@@ -1,0 +1,40 @@
+#
+# openldap_unique_indices.rb
+#
+
+module Puppet::Parser::Functions
+  newfunction(:openldap_unique_indices, :type => :rvalue, :doc => <<-EOS
+Takes an array of olcDbIndex attributes, and outputs an array of olcDbIndex
+attributes where each is unique (e.g. there are no repeated indices).
+
+*Example:*
+
+  openldap_unique_indices(['entryCSN,entryUUID eq', 'ou,cn eq,pres,sub', 'entryCSN eq', 'entryUUID eq'])
+
+Would result in:
+
+  ['entryCSN eq', 'entryUUID eq', 'ou eq,pres,sub', 'cn eq,pres,sub']
+
+EOS
+  ) do |arguments|
+
+    raise(Puppet::ParseError, 'size(): Wrong number of arguments ' +
+      "given (#{arguments.size} for 1)") if arguments.size < 1
+
+    indices = arguments[0]
+
+    unless indices.is_a?(Array)
+      raise(Puppet::ParseError, 'openldap_unique_indices(): Requires an ' +
+        'array to work with')
+    end
+
+    separate_indices = indices.reduce([]) { |memo, i|
+      index_parts = i.split
+      memo + index_parts[0].split(",").map { |attr|
+        "#{attr} #{index_parts[1]}"
+      }
+    }
+
+    return separate_indices.uniq
+  end
+end

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -24,7 +24,7 @@ class openldap::server (
   $data_index_cachesize      = undef,
   $db_backend                = $::openldap::params::db_backend,
   $group                     = $::openldap::params::group,
-  $indices                   = undef,
+  $indices                   = [],
   $ldap_interfaces           = $::openldap::params::ldap_interfaces,
   $ldaps_interfaces          = $::openldap::params::ldaps_interfaces,
   $limits                    = [],
@@ -101,9 +101,7 @@ class openldap::server (
   }
   validate_string($db_backend)
   validate_string($group)
-  if $indices {
-    validate_array($indices)
-  }
+  validate_array($indices)
   validate_array($ldap_interfaces)
   validate_array($ldaps_interfaces)
   if $limits {

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -193,7 +193,9 @@ class openldap::server::config {
     # required by the overlay
     $access  = flatten(["${replica_access} by * break",
       $::openldap::server::access])
-    $indices = flatten([$::openldap::server::indices, 'entryCSN,entryUUID eq'])
+    $indices = openldap_unique_indices(
+      flatten([$::openldap::server::indices, 'entryCSN,entryUUID eq'])
+    )
     $limits  = flatten([$replica_limits, $::openldap::server::limits])
 
     # accesslog overlay is required, i.e. delta-syncrepl
@@ -222,7 +224,11 @@ class openldap::server::config {
           'olcDbDNcacheSize'  => $::openldap::server::accesslog_dn_cachesize,
           'olcDbIDLcacheSize' => $::openldap::server::accesslog_index_cachesize,
           'olcDbIndex'        => [
-            'entryCSN,objectClass,reqEnd,reqResult,reqStart eq',
+            'entryCSN eq',
+            'objectClass eq',
+            'reqEnd eq',
+            'reqResult eq',
+            'reqStart eq',
           ],
           'olcLimits'         => openldap_values($replica_limits),
           'olcRootDN'         => $::openldap::server::root_dn,
@@ -257,10 +263,11 @@ class openldap::server::config {
 
     # If this is a slave/consumer, create necessary indices
     if $::openldap::server::syncrepl {
-      $indices = flatten([$::openldap::server::indices,
-        'entryCSN,entryUUID eq'])
+      $indices = openldap_unique_indices(
+        flatten([$::openldap::server::indices, 'entryCSN,entryUUID eq'])
+      )
     } else {
-      $indices = $::openldap::server::indices
+      $indices = openldap_unique_indices($::openldap::server::indices)
     }
 
     $limits = $::openldap::server::limits

--- a/spec/classes/openldap_server_spec.rb
+++ b/spec/classes/openldap_server_spec.rb
@@ -360,7 +360,7 @@ describe 'openldap::server' do
               'olcDbDirectory'    => ['/var/lib/ldap/data'],
               'olcDbDNcacheSize'  => ['1500'],
               'olcDbIDLcacheSize' => ['4500'],
-              'olcDbIndex'        => ['entryCSN,entryUUID eq'],
+              'olcDbIndex'        => ['entryCSN eq', 'entryUUID eq'],
               'olcLimits'         => [
                 '{0}dn.exact="cn=replicator,dc=example,dc=com" time.soft=unlimited time.hard=unlimited size.soft=unlimited size.hard=unlimited'
               ],
@@ -425,7 +425,7 @@ describe 'openldap::server' do
               ],
               'olcDatabase'    => ['{2}hdb'],
               'olcDbDirectory' => ['/var/lib/ldap/data'],
-              'olcDbIndex'     => ['entryCSN,entryUUID eq'],
+              'olcDbIndex'     => ['entryCSN eq', 'entryUUID eq'],
               'olcLimits'      => [
                 '{0}dn.exact="cn=replicator,dc=example,dc=com" time.soft=unlimited time.hard=unlimited size.soft=unlimited size.hard=unlimited'
               ],
@@ -502,7 +502,7 @@ describe 'openldap::server' do
               'olcDatabase'    => ['{2}hdb'],
               'olcDbDirectory' => ['/var/lib/ldap/log'],
               'olcDbIndex'     => [
-                'entryCSN,objectClass,reqEnd,reqResult,reqStart eq',
+                'entryCSN eq', 'objectClass eq', 'reqEnd eq', 'reqResult eq', 'reqStart eq'
               ],
               'olcLimits'      => [
                 '{0}dn.exact="cn=replicator,dc=example,dc=com" time.soft=unlimited time.hard=unlimited size.soft=unlimited size.hard=unlimited'
@@ -524,7 +524,7 @@ describe 'openldap::server' do
               ],
               'olcDatabase'    => ['{3}hdb'],
               'olcDbDirectory' => ['/var/lib/ldap/data'],
-              'olcDbIndex'     => ['entryCSN,entryUUID eq'],
+              'olcDbIndex'     => ['entryCSN eq', 'entryUUID eq'],
               'olcLimits'      => [
                 '{0}dn.exact="cn=replicator,dc=example,dc=com" time.soft=unlimited time.hard=unlimited size.soft=unlimited size.hard=unlimited'
               ],
@@ -614,7 +614,7 @@ describe 'openldap::server' do
               'olcDbDNcacheSize'  => ['1500'],
               'olcDbIDLcacheSize' => ['4500'],
               'olcDbIndex'        => [
-                'entryCSN,objectClass,reqEnd,reqResult,reqStart eq',
+                'entryCSN eq', 'objectClass eq', 'reqEnd eq', 'reqResult eq', 'reqStart eq'
               ],
               'olcLimits'         => [
                 '{0}dn.exact="cn=replicator,dc=example,dc=com" time.soft=unlimited time.hard=unlimited size.soft=unlimited size.hard=unlimited'
@@ -636,7 +636,7 @@ describe 'openldap::server' do
               ],
               'olcDatabase'    => ['{3}hdb'],
               'olcDbDirectory' => ['/var/lib/ldap/data'],
-              'olcDbIndex'     => ['entryCSN,entryUUID eq'],
+              'olcDbIndex'     => ['entryCSN eq', 'entryUUID eq'],
               'olcLimits'      => [
                 '{0}dn.exact="cn=replicator,dc=example,dc=com" time.soft=unlimited time.hard=unlimited size.soft=unlimited size.hard=unlimited'
               ],
@@ -743,7 +743,7 @@ describe 'openldap::server' do
               'olcDbDNcacheSize'  => ['1500'],
               'olcDbIDLcacheSize' => ['4500'],
               'olcDbIndex'        => [
-                'entryCSN,objectClass,reqEnd,reqResult,reqStart eq',
+                'entryCSN eq', 'objectClass eq', 'reqEnd eq', 'reqResult eq', 'reqStart eq'
               ],
               'olcLimits'         => [
                 '{0}dn.exact="cn=replicator,dc=example,dc=com" time.soft=unlimited time.hard=unlimited size.soft=unlimited size.hard=unlimited'
@@ -765,7 +765,7 @@ describe 'openldap::server' do
               ],
               'olcDatabase'    => ['{3}hdb'],
               'olcDbDirectory' => ['/var/lib/ldap/data'],
-              'olcDbIndex'     => ['entryCSN,entryUUID eq'],
+              'olcDbIndex'     => ['entryCSN eq', 'entryUUID eq'],
               'olcLimits'      => [
                 '{0}dn.exact="cn=replicator,dc=example,dc=com" time.soft=unlimited time.hard=unlimited size.soft=unlimited size.hard=unlimited'
               ],
@@ -858,7 +858,7 @@ describe 'openldap::server' do
               'olcAccess'      => ['{0}to * by dn.base="gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth" manage'],
               'olcDatabase'    => ['{2}hdb'],
               'olcDbDirectory' => ['/var/lib/ldap/data'],
-              'olcDbIndex'     => ['entryCSN,entryUUID eq'],
+              'olcDbIndex'     => ['entryCSN eq', 'entryUUID eq'],
               'olcRootDN'      => ['cn=Manager,dc=example,dc=com'],
               'olcRootPW'      => ['secret'],
               'olcSuffix'      => ['dc=example,dc=com'],

--- a/spec/functions/openldap_unique_indices_spec.rb
+++ b/spec/functions/openldap_unique_indices_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'openldap_unique_indices' do
+  it { should run.with_params(
+    ['entryCSN,entryUUID eq', 'ou,cn eq,pres,sub', 'entryCSN eq', 'entryUUID eq']
+  ).and_return(
+    ['entryCSN eq', 'entryUUID eq', 'ou eq,pres,sub', 'cn eq,pres,sub'])
+  }
+  it { should run.with_params(['entryCSN eq']).and_return(
+    ['entryCSN eq'])
+  }
+  it { should run.with_params([]).and_return([]) }
+end


### PR DESCRIPTION
Prior to this commit, adding a entryUUID or entryCSN
index conflicted with those being added by default
when the syncprov overlay is enabled.

This avoids that behavior by canonicalizing and uniquing
the indices before adding them into OpenLDAP.
