### PR TITLE
Adds support for unique overlay

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,7 @@ class openldap::params {
   $ssl_protocol        = undef
   $syncprov_checkpoint = '100 10'
   $syncprov_sessionlog = 100
+  $unique_uris         = undef
 
   case $::osfamily {
     'RedHat': {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -52,6 +52,8 @@ class openldap::server (
   $syncprov_sessionlog       = $::openldap::params::syncprov_sessionlog,
   $syncrepl                  = undef,
   $time_limit                = undef,
+  $unique                    = false,
+  $unique_uris               = $::openldap::params::unique_uris,
   $update_ref                = undef,
   $user                      = $::openldap::params::user,
 ) inherits ::openldap::params {
@@ -161,6 +163,10 @@ class openldap::server (
   }
   if $time_limit {
     validate_re("${time_limit}", '^(?:(time)(?:\.\w+)?=)?(?:\d+|unlimited)(?:\s+\1(?:\.\w+)?=(?:\d+|unlimited))*$') # lint:ignore:80chars lint:ignore:only_variable_string
+  }
+  validate_bool($unique)
+  if $unique {
+    validate_array($unique_uris)
   }
   if $update_ref {
     validate_array($update_ref)

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -96,6 +96,10 @@ class openldap::server::config {
       true    => 'smbk5pwd',
       default => '',
     },
+    $::openldap::server::unique ? {
+      true    => 'unique',
+      default => '',
+    },
   ]
 
   $overlays = reject($overlay_candidates, '^\s*$')
@@ -379,6 +383,21 @@ class openldap::server::config {
         'olcOverlay'            => $overlay_index['smbk5pwd'],
         'olcSmbK5PwdEnable'     => $::openldap::server::smbk5pwd_backends,
         'olcSmbK5PwdMustChange' => $::openldap::server::smbk5pwd_must_change,
+      }),
+      require    => Openldap['cn=module{0},cn=config'],
+    }
+  }
+
+  if $::openldap::server::unique {
+    openldap {"olcOverlay=${overlay_index['unique']},olcDatabase={${db_index}}${db_backend},cn=config": #lint:ignore:80chars
+      ensure     => present,
+      attributes => delete_undef_values({
+        'objectClass'  => [
+          'olcOverlayConfig',
+          'olcUniqueConfig',
+        ],
+        'olcOverlay'   => $overlay_index['unique'],
+        'olcUniqueURI' => $::openldap::server::unique_uris,
       }),
       require    => Openldap['cn=module{0},cn=config'],
     }

--- a/spec/classes/openldap_server_spec.rb
+++ b/spec/classes/openldap_server_spec.rb
@@ -397,6 +397,84 @@ describe 'openldap::server' do
           end
         end
 
+        context 'with unique enabled', :compile do
+          let(:params) do
+            super().merge(
+              {
+                :unique      => true,
+                :unique_uris => [
+                  'ldap:///dc=example,dc=com?uidNumber?sub',
+                  'ldap:///dc=example,dc=com?homeDirectory?sub',
+                ],
+              }
+            )
+          end
+
+          it_behaves_like "openldap::server on #{facts[:osfamily]}"
+
+          it { should contain_openldap('olcDatabase={-1}frontend,cn=config').with_attributes(
+            {
+              'objectClass'  => [
+                'olcDatabaseConfig',
+                'olcFrontendConfig',
+              ],
+              'olcDatabase'  => ['{-1}frontend'],
+            }
+          ) }
+          it { should contain_openldap('olcDatabase={2}hdb,cn=config').with_attributes(
+            {
+              'objectClass'    => [
+                'olcDatabaseConfig',
+                'olcHdbConfig',
+              ],
+              'olcAccess'      => ['{0}to * by dn.base="gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth" manage'],
+              'olcDatabase'    => ['{2}hdb'],
+              'olcDbDirectory' => ['/var/lib/ldap/data'],
+              'olcRootDN'      => ['cn=Manager,dc=example,dc=com'],
+              'olcRootPW'      => ['secret'],
+              'olcSuffix'      => ['dc=example,dc=com'],
+            }
+          ) }
+          it { should contain_openldap('olcOverlay={0}unique,olcDatabase={2}hdb,cn=config').with_attributes(
+            {
+              'objectClass'     => [
+                'olcOverlayConfig',
+                'olcUniqueConfig',
+              ],
+              'olcOverlay'      => ['{0}unique'],
+              'olcUniqueURI' => [
+                'ldap:///dc=example,dc=com?uidNumber?sub',
+                'ldap:///dc=example,dc=com?homeDirectory?sub',
+              ],
+            }
+          ) }
+
+          case facts[:osfamily]
+          when 'Debian'
+            it { should contain_openldap('cn=module{0},cn=config').with_attributes(
+              {
+                'cn'            => ['module{0}'],
+                'objectClass'   => ['olcModuleList'],
+                'olcModuleLoad' => [
+                  '{0}back_monitor.la',
+                  '{1}back_hdb.la',
+                  '{2}unique.la',
+                ],
+              }
+            ) }
+          when 'RedHat'
+            it { should contain_openldap('cn=module{0},cn=config').with_attributes(
+              {
+                'cn'            => ['module{0}'],
+                'objectClass'   => ['olcModuleList'],
+                'olcModuleLoad' => [
+                  '{0}unique.la',
+                ],
+              }
+            ) }
+          end
+        end
+
         context 'with syncrepl and auditlog enabled', :compile do
           let(:params) do
             super().merge(

--- a/spec/fixtures/files/unique.ldif
+++ b/spec/fixtures/files/unique.ldif
@@ -1,0 +1,9 @@
+dn: uid=bob,ou=people,dc=example,dc=com
+objectClass: inetOrgPerson
+objectClass: posixAccount
+uid: bob
+sn: Example
+cn: Bob Example
+uidNumber: 1000
+gidNumber: 1000
+homeDirectory: /home/bob

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -17,6 +17,7 @@ RSpec.configure do |c|
       on host, puppet('module', 'install', 'puppetlabs-firewall'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'saz-rsyslog'),         { :acceptable_exit_codes => [0,1] }
       scp_to(host, File.join(proj_root, 'spec/fixtures/files/example.ldif'), '/root/example.ldif')
+      scp_to(host, File.join(proj_root, 'spec/fixtures/files/unique.ldif'), '/root/unique.ldif')
       # Install SSL certs and key
       #scp_to(host, File.join(proj_root, 'spec/fixtures/files/ca.crt'), '/etc/pki/tls/ca.crt')
       #scp_to(host, File.join(proj_root, "spec/fixtures/files/#{host}.key"), '/etc/pki/tls/ldap.key')


### PR DESCRIPTION
This commit adds support for the unique overlay, which is used to define
rules about which attributes should be unique within which scope.
