### PR TITLE
Adds support for ppolicy overlay.

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -33,6 +33,10 @@ class openldap::server (
   $module_extension          = $::openldap::params::module_extension,
   $package_name              = $::openldap::params::server_package_name,
   $pid_file                  = $::openldap::params::pid_file,
+  $ppolicy                   = false,
+  $pp_hash_cleartext         = undef,
+  $pp_use_lockout            = undef,
+  $pp_forward_updates        = undef,
   $replica_dn                = undef,
   $schema_dir                = $::openldap::params::schema_dir,
   $security                  = undef,
@@ -115,6 +119,11 @@ class openldap::server (
   }
   validate_string($package_name)
   validate_absolute_path($pid_file)
+  if $ppolicy {
+    validate_re($pp_hash_cleartext, '^TRUE$|^FALSE$')
+    validate_re($pp_use_lockout, '^TRUE$|^FALSE$')
+    validate_re($pp_forward_updates, '^TRUE$|^FALSE$')
+  }
   validate_absolute_path($schema_dir)
   if $security {
     validate_re($security, '^\w+=\d+(?:\s+\w+=\d+)*$')

--- a/spec/fixtures/files/ppolicy_overlay.ldif
+++ b/spec/fixtures/files/ppolicy_overlay.ldif
@@ -1,0 +1,9 @@
+dn: cn=passwordDefault,dc=example,dc=com
+objectClass: top
+objectClass: person
+objectClass: pwdPolicy
+cn: passwordDefault
+sn: passwordDefault
+pwdAttribute: userPassword
+pwdCheckQuality: 2
+pwdMinLength: 8

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -17,6 +17,7 @@ RSpec.configure do |c|
       on host, puppet('module', 'install', 'puppetlabs-firewall'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'saz-rsyslog'),         { :acceptable_exit_codes => [0,1] }
       scp_to(host, File.join(proj_root, 'spec/fixtures/files/example.ldif'), '/root/example.ldif')
+      scp_to(host, File.join(proj_root, 'spec/fixtures/files/ppolicy_overlay.ldif'), '/root/ppolicy_overlay.ldif')
       # Install SSL certs and key
       #scp_to(host, File.join(proj_root, 'spec/fixtures/files/ca.crt'), '/etc/pki/tls/ca.crt')
       #scp_to(host, File.join(proj_root, "spec/fixtures/files/#{host}.key"), '/etc/pki/tls/ldap.key')


### PR DESCRIPTION
This adds support for the ppolicy overlay, by adding the necessary
changes to the cn=config database. The user will be required to activate
the ppolicy schema, and any password enforcement will rely on a user
defined default password object at cn=passwordDefault,<olcSuffix>.
