### PR TITLE
Adds support for StartTLS on chain overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,12 @@ chain overlay.
 
 Maps to the `olcChainReturnError` attribute on the chain overlay.
 
+##### `chain_tls`
+
+Maps to the `olcDbStartTLS` attribute on the chain overlay. See the `tls` 
+entry on the `slapd-ldap` man page for more information on usage and accepted
+values.
+
 ##### `data_cachesize`
 
 Specify the size of the in-memory entry cache maintained by the `bdb` or

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -21,6 +21,7 @@ class openldap::server (
   $chain_id_assert_bind      = undef,
   $chain_rebind_as_user      = undef,
   $chain_return_error        = undef,
+  $chain_tls                 = undef,
   $data_cachesize            = undef,
   $data_checkpoint           = undef,
   $data_db_config            = [],
@@ -110,6 +111,9 @@ class openldap::server (
     }
     if $chain_return_error {
       validate_bool($chain_return_error)
+    }
+    if $chain_tls {
+      validate_string($chain_tls)
     }
   }
   if $data_cachesize {

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -208,6 +208,7 @@ class openldap::server::config {
         'olcDbURI'          => $::openldap::server::update_ref,
         'olcDbRebindAsUser' => $_chain_rebind_as_user,
         'olcDbIDAssertBind' => $::openldap::server::chain_id_assert_bind,
+        'olcDbStartTLS'     => $::openldap::server::chain_tls,
       }),
     }
   }

--- a/spec/classes/openldap_server_spec.rb
+++ b/spec/classes/openldap_server_spec.rb
@@ -1062,6 +1062,7 @@ describe 'openldap::server' do
                 :chain_id_assert_bind => 'mode=self flags=proxy-authz-critical',
                 :chain_rebind_as_user => true,
                 :chain_return_error   => true,
+                :chain_tls            => 'start',
                 :syncrepl             => [
                   'rid=001 provider=ldap://ldap.example.com/',
                 ],
@@ -1094,6 +1095,7 @@ describe 'openldap::server' do
               'olcDbURI'          => ['ldap://ldap.example.com/'],
               'olcDbRebindAsUser' => ['TRUE'],
               'olcDbIDAssertBind' => ['mode=self flags=proxy-authz-critical'],
+              'olcDbStartTLS'     => ['start'],
             }
           ) }
           it { should contain_openldap('olcDatabase={2}hdb,cn=config').with_attributes(


### PR DESCRIPTION
This commit allows the olcDbStartTLS attribute to be set on the
chain overlay, as chain_tls. This lets the user specify how the
replica LDAP servers should use the StartTLS operation when
communicating with the primary.
